### PR TITLE
Switched to new test architecture

### DIFF
--- a/PathFinder/PathFinder.hs
+++ b/PathFinder/PathFinder.hs
@@ -1,30 +1,49 @@
-module PathFinder.PathFinder (path) where
+module PathFinder.PathFinder (path, isConnected) where
 
-import Data.List hiding (insert)
-import Data.Map hiding ((\\), foldr)
 
+
+import Control.Applicative
+import Data.Maybe
+import Data.List           hiding (insert)
+import Data.Map            hiding ((\\), foldr)
 import PathFinder.Graph
+
+
 
 type VisitedNodes a = Map a (Int, Maybe a)
 
+
+
 path :: Ord a => Graph a -> a -> a -> Maybe [a]
-path g from to = path' g from to (singleton to (0, Nothing))
+path g from to = buildPath to <$> extendMapUntil foundFrom g (emptyMap to)
+  where foundFrom = (from `member`)
 
-path' g f t m
-  | f `member` m = Just $ buildPath m f
-  | otherwise    = let m' = foldr (extend g) m (keys m) in
-                    if m' == m then Nothing else path' g f t m'
+isConnected :: Ord a => Graph a -> Bool
+isConnected g = isJust $ extendMapUntil isFull g (emptyMap start)
+  where isFull m = length (keys m) == length (nodes g)
+        start = label (head $ nodes g)
 
-buildPath :: Ord a => VisitedNodes a -> a -> [a]
-buildPath m n = let (_, mp) = m ! n in
-                  case mp of
-                   Nothing -> [n]
-                   Just p  -> n : buildPath m p
 
-extend :: Ord a => Graph a -> a -> VisitedNodes a -> VisitedNodes a
-extend g n m =
+
+emptyMap :: Ord a => a -> VisitedNodes a
+emptyMap s = singleton s (0, Nothing)
+
+extendMap :: Ord a => Graph a -> a -> VisitedNodes a -> VisitedNodes a
+extendMap g n m =
   let (l, _) = m ! n
       ps = parents g n
       ns = ps \\ keys m in
   foldr (\p -> insert p (l + 1, Just n)) m ns
+
+extendMapUntil :: Ord a => (VisitedNodes a -> Bool) -> Graph a -> VisitedNodes a -> Maybe (VisitedNodes a)
+extendMapUntil p g m
+  | p m       = Just m
+  | otherwise = let m' = foldr (extendMap g) m (keys m) in
+                    if m' == m then Nothing else extendMapUntil p g m'
+
+buildPath :: Ord a => a -> VisitedNodes a -> [a]
+buildPath n m = let (_, mp) = m ! n in
+                 case mp of
+                  Nothing -> [n]
+                  Just p  -> n : buildPath p m
 

--- a/tests/tests.hs
+++ b/tests/tests.hs
@@ -1,35 +1,41 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+
+import System.Exit
+import Data.List
 import Data.Maybe
 import Control.Monad
 import Control.Applicative
 import Test.QuickCheck
+import Test.QuickCheck.All
+import Test.QuickCheck.Test
 import PathFinder.Graph as G
 import PathFinder.PathFinder
 
-newtype ConnectedGraph    a = CG { cg :: Graph a }
-newtype DisconnectedGraph a = DG { dg :: Graph a }
 
-instance Arbitrary a => Arbitrary (ConnectedGraph a) where
-  arbitrary = join (foldr build start <$> labels)
-    where labels        = arbitrary `suchThat` isBigEnough -- Gen [a]
-          build l       = (>>= addToCG l)                  -- a -> Gen (ConnectedGraph a) -> Gen (ConnectedGraph a)
-          start         = return (CG G.empty)              -- Gen (ConnectedGraph a)
-          isBigEnough x = length x > 2                     -- [a] -> Bool
 
-addToCG :: a -> ConnectedGraph a -> Gen (ConnectedGraph a)
-addToCG newLabel connectedGraph
-  | null (nodes graph) = return singleton
-  | otherwise          = fmap buildGraph oldLabelGen
-  where graph        = cg connectedGraph                               -- Graph a
-        singleton    = CG $ Graph [Node newLabel] []                   -- ConnectedGraph a
-        oldLabelGen  = G.label <$> elements (nodes graph)              -- Gen a
-        newNodes     = Node newLabel : nodes graph                     -- [Node a]
-        newEdges l   = Edge l newLabel : Edge newLabel l : edges graph -- a -> [Edge a]
-        buildGraph l = CG $ Graph newNodes (newEdges l)                -- a -> ConnectedGraph a
+instance (Arbitrary a, Eq a) => Arbitrary (Graph a) where
+  arbitrary = do
+    nodes <- nub <$> listOf1 arbitrary
+    esize <- arbitrary `suchThat` (< 2 * length nodes)
+    edges <- (nub . concat) <$> (vectorOf esize
+                                 (do f <- elements nodes
+                                     t <- elements nodes `suchThat` (/= f)
+                                     return [(f, t), (t, f)]))
+    return $ Graph (map Node nodes) (map (uncurry Edge) edges)
 
-nodesWorks :: [String] -> String -> Bool
-nodesWorks ls l = (l `elem` ls) == isJust (node g l)
+
+
+prop_nodesWorks :: Eq a => [a] -> a -> Bool
+prop_nodesWorks ls l = (l `elem` ls) == isJust (node g l)
   where ns = fmap Node ls
         g = Graph ns []
 
-test = quickCheck . verbose
-main = test nodesWorks
+prop_connectedPaths :: Ord a => Graph a -> Bool
+prop_connectedPaths g = isConnected g == all isJust [path g x y | (Node x) <- nodes g, (Node y) <- nodes g]
+
+
+
+main = do
+  result <- $quickCheckAll
+  unless result exitFailure


### PR DESCRIPTION
So, I refactored according to what was discussed. I used this opportunity to clean a few things in PathFinder and to switch to a proper quickCheck API.

The new arbitrary graph generator, however nice, revealed a few flaws: allowing duplicated edges will create an infinite recursion. We should transform the test to a `Property` and use `within` to ensure we fail fast instead of crashing in those cases.

We should also think about the way we could enforce having no duplicated labels / edges when creating a graph. We could maybe hide the "Graph" constructor and only provide a partial "makeGraph" function that errors on invalid input?
